### PR TITLE
Reindent `package.json` to use 4 spaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,34 +1,34 @@
 {
-  "name": "idf-handbook",
-  "version": "1.0.0",
-  "description": "IDF Company handbook for developers",
-  "main": "README.md",
-  "scripts": {
-    "test": "npm run style:lint",
-    "style:lint": "prettier \"**/*.md\"",
-    "style:fix": "prettier \"**/*.md\" --write"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/InteractionDesignFoundation/handbook.git"
-  },
-  "keywords": [
-    "handbook",
-    "company culture",
-    "engeneering culture"
-  ],
-  "bugs": {
-    "url": "https://github.com/InteractionDesignFoundation/handbook/issues"
-  },
-  "homepage": "https://github.com/InteractionDesignFoundation/handbook#readme",
-  "dependencies": {
-    "husky": "^1.3.1",
-    "prettier": "^1.15.3",
-    "pretty-quick": "^1.9.0"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "pretty-quick --staged"
+    "name": "idf-handbook",
+    "version": "1.0.0",
+    "description": "IDF Company handbook for developers",
+    "main": "README.md",
+    "scripts": {
+        "test": "npm run style:lint",
+        "style:lint": "prettier \"**/*.md\"",
+        "style:fix": "prettier \"**/*.md\" --write"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/InteractionDesignFoundation/handbook.git"
+    },
+    "keywords": [
+        "handbook",
+        "company culture",
+        "engeneering culture"
+    ],
+    "bugs": {
+        "url": "https://github.com/InteractionDesignFoundation/handbook/issues"
+    },
+    "homepage": "https://github.com/InteractionDesignFoundation/handbook#readme",
+    "dependencies": {
+        "husky": "^1.3.1",
+        "prettier": "^1.15.3",
+        "pretty-quick": "^1.9.0"
+    },
+    "husky": {
+        "hooks": {
+            "pre-commit": "pretty-quick --staged"
+        }
     }
-  }
 }


### PR DESCRIPTION
This PR doesn't bring any changes to `package.json`, it just fixes its indentation.

"4 spaces" is kinda standard for indentation, because it's much more readable.

Also, as I've checked we use 4 spaces for `package.json` (and `composer.json`) in our private IDF repos, so I think it's much more consistent to have the same indentation here too.