### PR TITLE
Fix typos in Onboarding docs

### DIFF
--- a/guides/onboarding/onboarding--mentorGuide.md
+++ b/guides/onboarding/onboarding--mentorGuide.md
@@ -34,7 +34,7 @@ Ensure your mentee understands your expectations and feels motivated to fill the
     Why: It will help your mentee understand if they are doing things at the right pace and focusing on the correct tasks, as well as receive clear instructions, advice and constructive criticism to help them improve.
 1.  Start changing code: Prepare 3-10 tasks for smooth entry into the project. Examples:
     1. Write tests for feature X (the goal is to introduce feature X, introduce out tools and workflows (GitHub, git, CI))
-    1. Pickup and fix any bug from our automated but-report systems (NewRelic, Bugsnag, etc.) (goal: introduce tools, fix a bug)
+    1. Pickup and fix any bug from our automated but-report systems (New Relic, Bugsnag, etc.) (goal: introduce tools, fix a bug)
     1. Review a Pull Request (goal: introduce our Pull Request flow and a new piece of code).
 
 ### First week
@@ -72,7 +72,7 @@ This is a list of tools and services that a new member should have access to:
 - [LastPass](https://www.lastpass.com/): Credentials management tool: store and share credentials.
 - [Laravel Forge](https://forge.laravel.com): Provision and deployment service for our servers & sites.
 - [Digital Ocean](https://www.digitalocean.com): Our server provider.
-- [NewRelic](https://newrelic.com/): Log errors and monitor application performance (get shared credentials from credential management tool).
+- [New Relic](https://newrelic.com/): Log errors and monitor application performance (get shared credentials from credential management tool).
 - [CodeShip](https://codeship.com/): Continuous integration tool (get shared credentials from credential management tool).
 - [GTmetrix](https://gtmetrix.com/): Analyze web page's speed performance (get shared credentials from credential management tool).
 - [Zeplin](https://zeplin.io/): Share designs and its assets between designer and developers.

--- a/guides/onboarding/onboarding--mentorGuide.md
+++ b/guides/onboarding/onboarding--mentorGuide.md
@@ -34,8 +34,8 @@ Ensure your mentee understands your expectations and feels motivated to fill the
     Why: It will help your mentee understand if they are doing things at the right pace and focusing on the correct tasks, as well as receive clear instructions, advice and constructive criticism to help them improve.
 1.  Start changing code: Prepare 3-10 tasks for smooth entry into the project. Examples:
     1. Write tests for feature X (the goal is to introduce feature X, introduce out tools and workflows (GitHub, git, CI))
-    1. Pickup and fix any bug from our automated but-report systems (Newrelic, Bugsnag, etc.) (goal: introduce tools, fix a bug)
-    1. Review a Pull Request (goal: introduce our Pull Reequest flow and a new piece of code).
+    1. Pickup and fix any bug from our automated but-report systems (NewRelic, Bugsnag, etc.) (goal: introduce tools, fix a bug)
+    1. Review a Pull Request (goal: introduce our Pull Request flow and a new piece of code).
 
 ### First week
 
@@ -72,8 +72,8 @@ This is a list of tools and services that a new member should have access to:
 - [LastPass](https://www.lastpass.com/): Credentials management tool: store and share credentials.
 - [Laravel Forge](https://forge.laravel.com): Provision and deployment service for our servers & sites.
 - [Digital Ocean](https://www.digitalocean.com): Our server provider.
-- [Newrelic](https://newrelic.com/): Log errors and monitor application performance (get shared credentials from credential management tool).
-- [Codeship](https://codeship.com/): Continuous integration tool (get shared credentials from credential management tool).
+- [NewRelic](https://newrelic.com/): Log errors and monitor application performance (get shared credentials from credential management tool).
+- [CodeShip](https://codeship.com/): Continuous integration tool (get shared credentials from credential management tool).
 - [GTmetrix](https://gtmetrix.com/): Analyze web page's speed performance (get shared credentials from credential management tool).
 - [Zeplin](https://zeplin.io/): Share designs and its assets between designer and developers.
 - Optional: [Google analytics](https://analytics.google.com): Analytics service that tracks and reports website traffic.


### PR DESCRIPTION
Just a few typos + things like `Newrelic` => `NewRelic`.

-----
[View rendered guides/onboarding/onboarding--mentorGuide.md](https://github.com/InteractionDesignFoundation/handbook/blob/onboarding-mentor-typos/guides/onboarding/onboarding--mentorGuide.md)