### PR TITLE
Escape curly braces so they print to the screen

### DIFF
--- a/development/library/back-end/conventions--laravel.md
+++ b/development/library/back-end/conventions--laravel.md
@@ -592,7 +592,7 @@ Laravel Blade protects from most XSS attacks, so for example an attack like this
 <div>{{ $name }}</div>
 ```
 
-Blade’s `{{ }}` statement automatically encodes the output. So the server will send the following properly encoded code to the browser (which will prevent the XSS attack):
+Blade’s `@{{ }}` statement automatically encodes the output. So the server will send the following properly encoded code to the browser (which will prevent the XSS attack):
 
 ```html
 <div>John Doe&lt;script&gt;alert(&quot;xss&quot;);&lt;/script&gt;</div>


### PR DESCRIPTION
The double curly braces get parsed and aren't visible here https://handbook.interaction-design.org/development/library/back-end/conventions--laravel.html#xss-in-laravel-blade without being escaped:

<img width="666" alt="Screen Shot 2022-04-25 at 3 02 00 PM" src="https://user-images.githubusercontent.com/217390/165182576-fca54e85-bf36-46f5-9b1e-3729c3d65c88.png">

-----
[View rendered development/library/back-end/conventions--laravel.md](https://github.com/Adam42/handbook/blob/patch-2/development/library/back-end/conventions--laravel.md)