### PR TITLE
Fix typos

### DIFF
--- a/development/guides/scrum/README.md
+++ b/development/guides/scrum/README.md
@@ -35,7 +35,7 @@ Small team of people, consists of:
 The main goal of these events is to create regularity and minimize the need for meetings.
 
 -   **[Sprint](https://www.scrum.org/resources/what-is-a-sprint-in-scrum)**:
-    It is the heart-beat of scrum, which encompasses all the work necessary to achive the Product Goal.
+    It is the heart-beat of scrum, which encompasses all the work necessary to achieve the Product Goal.
     It's a fixed-length event of one month or less.
 -   **[Sprint Planning](https://www.scrum.org/resources/what-is-sprint-planning)**: Initiates the sprint by laying out the work to be done.
     -   Questions:
@@ -80,7 +80,7 @@ Scrum Artifacts enable inspection & adaptation by providing transparency on the 
         -   Set of Product Backlog Items (What)
         -   Actionable plan for delivering the Increment (How)
         -   Commitment: Sprint Goal, which is a single commitment for the sprint. It has
-            flexibility in terms of the exact work needed to achive it.
+            flexibility in terms of the exact work needed to achieve it.
 -   **[Increment](https://www.scrum.org/resources/what-is-an-increment)**:
     -   Definition:
         -   Concrete stepping stone toward the Product Goal.

--- a/development/library/back-end/clean-code-php.md
+++ b/development/library/back-end/clean-code-php.md
@@ -1300,7 +1300,7 @@ $balance = $bankAccount->getBalance();
 
 Therefore, use `private` by default and `public/protected` when you need to provide access for external classes.
 
-For more informations you can read the [blog post](http://fabien.potencier.org/pragmatism-over-theory-protected-vs-private.html) on this topic written by [Fabien Potencier](https://github.com/fabpot).
+For more information you can read the [blog post](http://fabien.potencier.org/pragmatism-over-theory-protected-vs-private.html) on this topic written by [Fabien Potencier](https://github.com/fabpot).
 
 **Bad:**
 
@@ -1457,7 +1457,7 @@ more often it comes at some costs:
 3. Is harder to [mock](https://en.wikipedia.org/wiki/Mock_object) in a test suite.
 4. Makes diffs of commits harder to read.
 
-For more informations you can read the full [blog post](https://ocramius.github.io/blog/fluent-interfaces-are-evil/)
+For more information you can read the full [blog post](https://ocramius.github.io/blog/fluent-interfaces-are-evil/)
 on this topic written by [Marco Pivetta](https://github.com/Ocramius).
 
 **Bad:**
@@ -1557,7 +1557,7 @@ The `final` should be used whenever possible:
 
 The only condition is that your class should implement an interface and no other public methods are defined.
 
-For more informations you can read [the blog post](https://ocramius.github.io/blog/when-to-declare-classes-final/) on this topic written by [Marco Pivetta (Ocramius)](https://ocramius.github.io/).
+For more information you can read [the blog post](https://ocramius.github.io/blog/when-to-declare-classes-final/) on this topic written by [Marco Pivetta (Ocramius)](https://ocramius.github.io/).
 
 **Bad:**
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "keywords": [
         "handbook",
         "company culture",
-        "engeneering culture"
+        "engineering culture"
     ],
     "bugs": {
         "url": "https://github.com/InteractionDesignFoundation/handbook/issues"


### PR DESCRIPTION
Correct every misspelling `typos` could find.

Please consider using Grammarly.
