### PR TITLE
Fix method signature in SOLID documentation

### DIFF
--- a/library/backend/SOLID.md
+++ b/library/backend/SOLID.md
@@ -54,7 +54,7 @@ interface ReportFormatter
 
 class HtmlReportFormatter implements ReportFormatter
 {
-    public function format()
+    public function format(Report $report)
     {
         $output = '';
         // ...


### PR DESCRIPTION
### Goal

Given interface and implementation signatures didn't match in the documentation